### PR TITLE
feat: refactor table builder with column specs and features

### DIFF
--- a/javafx-table-lib/pom.xml
+++ b/javafx-table-lib/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.growthfolio</groupId>
+    <artifactId>javafx-table-lib</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <javafx.version>21.0.2</javafx.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>linux</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>linux</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>linux</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/javafx-table-lib/src/main/java/com/growthfolio/table/ColumnSpec.java
+++ b/javafx-table-lib/src/main/java/com/growthfolio/table/ColumnSpec.java
@@ -1,0 +1,52 @@
+package com.growthfolio.table;
+
+import java.util.function.Function;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.StringProperty;
+import javafx.beans.value.ObservableValue;
+
+/**
+ * Specification for a table column. Holds metadata and value extraction logic.
+ *
+ * @param <T> row type
+ * @param <R> cell value type
+ */
+public class ColumnSpec<T, R> {
+
+    private final String id;
+    private final String title;
+    private final Function<T, ObservableValue<R>> valueProvider;
+
+    private ColumnSpec(String id, String title, Function<T, ObservableValue<R>> valueProvider) {
+        this.id = id;
+        this.title = title;
+        this.valueProvider = valueProvider;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public Function<T, ObservableValue<R>> valueProvider() {
+        return valueProvider;
+    }
+
+    public static <T, R> ColumnSpec<T, R> of(String id, String title,
+            Function<T, ObservableValue<R>> provider) {
+        return new ColumnSpec<>(id, title, provider);
+    }
+
+    public static <T> ColumnSpec<T, String> of(String id, String title,
+            Function<T, StringProperty> provider) {
+        return new ColumnSpec<>(id, title, t -> provider.apply(t));
+    }
+
+    public static <T> ColumnSpec<T, Integer> number(String id, String title,
+            Function<T, IntegerProperty> provider) {
+        return new ColumnSpec<>(id, title, t -> provider.apply(t).asObject());
+    }
+}

--- a/javafx-table-lib/src/main/java/com/growthfolio/table/GenericTableBuilder.java
+++ b/javafx-table-lib/src/main/java/com/growthfolio/table/GenericTableBuilder.java
@@ -1,0 +1,56 @@
+package com.growthfolio.table;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.TableView;
+
+import java.util.List;
+
+/**
+ * Utility builder for creating JavaFX {@link TableView} instances in a
+ * concise and type-safe way.
+ *
+ * @param <T> type of the row objects
+ */
+public class GenericTableBuilder<T> {
+
+    private final TableView<T> table;
+    private final TableBuilderOptions options = new TableBuilderOptions();
+
+    /**
+     * Creates a builder with the provided data.
+     *
+     * @param data list of row objects
+     */
+    public GenericTableBuilder(List<T> data) {
+        ObservableList<T> observableData = FXCollections.observableArrayList(data);
+        this.table = new TableView<>(observableData);
+    }
+
+    /**
+     * Adds a new column defined by the given {@link ColumnSpec}.
+     *
+     * @param spec column specification
+     * @param <R>  cell value type
+     * @return builder instance for method chaining
+     */
+    public <R> GenericTableBuilder<T> addColumn(ColumnSpec<T, R> spec) {
+        table.getColumns().add(TableColumnBuilder.build(spec));
+        return this;
+    }
+
+    public GenericTableBuilder<T> features(TableFeatures features) {
+        options.features(features);
+        return this;
+    }
+
+    /**
+     * Builds and returns the configured {@link TableView}.
+     *
+     * @return table view instance
+     */
+    public TableView<T> build() {
+        return table;
+    }
+}
+

--- a/javafx-table-lib/src/main/java/com/growthfolio/table/TableBuilderOptions.java
+++ b/javafx-table-lib/src/main/java/com/growthfolio/table/TableBuilderOptions.java
@@ -1,0 +1,18 @@
+package com.growthfolio.table;
+
+/**
+ * Options used during table building.
+ */
+public class TableBuilderOptions {
+
+    private TableFeatures features = TableFeatures.none();
+
+    public TableBuilderOptions features(TableFeatures features) {
+        this.features = features;
+        return this;
+    }
+
+    public TableFeatures getFeatures() {
+        return features;
+    }
+}

--- a/javafx-table-lib/src/main/java/com/growthfolio/table/TableColumnBuilder.java
+++ b/javafx-table-lib/src/main/java/com/growthfolio/table/TableColumnBuilder.java
@@ -1,0 +1,19 @@
+package com.growthfolio.table;
+
+import javafx.scene.control.TableColumn;
+
+/**
+ * Utility to build JavaFX {@link TableColumn} instances from {@link ColumnSpec}.
+ */
+public final class TableColumnBuilder {
+
+    private TableColumnBuilder() {
+    }
+
+    public static <T, R> TableColumn<T, R> build(ColumnSpec<T, R> spec) {
+        TableColumn<T, R> column = new TableColumn<>(spec.title());
+        column.setId(spec.id());
+        column.setCellValueFactory(cell -> spec.valueProvider().apply(cell.getValue()));
+        return column;
+    }
+}

--- a/javafx-table-lib/src/main/java/com/growthfolio/table/TableFeatures.java
+++ b/javafx-table-lib/src/main/java/com/growthfolio/table/TableFeatures.java
@@ -1,0 +1,52 @@
+package com.growthfolio.table;
+
+/**
+ * Flags enabling optional table features.
+ */
+public class TableFeatures {
+
+    private boolean filtering;
+    private boolean pagination;
+    private boolean export;
+    private boolean editable;
+
+    public static TableFeatures none() {
+        return new TableFeatures();
+    }
+
+    public TableFeatures enableFiltering() {
+        this.filtering = true;
+        return this;
+    }
+
+    public TableFeatures enablePagination() {
+        this.pagination = true;
+        return this;
+    }
+
+    public TableFeatures enableExport() {
+        this.export = true;
+        return this;
+    }
+
+    public TableFeatures editable(boolean editable) {
+        this.editable = editable;
+        return this;
+    }
+
+    public boolean isFiltering() {
+        return filtering;
+    }
+
+    public boolean isPagination() {
+        return pagination;
+    }
+
+    public boolean isExport() {
+        return export;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+}

--- a/javafx-table-lib/src/test/java/com/growthfolio/table/GenericTableBuilderTest.java
+++ b/javafx-table-lib/src/test/java/com/growthfolio/table/GenericTableBuilderTest.java
@@ -1,0 +1,39 @@
+package com.growthfolio.table;
+
+import javafx.application.Platform;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.control.TableView;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GenericTableBuilderTest {
+
+    @BeforeAll
+    static void initToolkit() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.startup(latch::countDown);
+        latch.await();
+    }
+
+    record Person(String name, int age) {}
+
+    @Test
+    void buildsTableWithColumnsAndData() {
+        List<Person> data = List.of(new Person("Ana", 30), new Person("Bob", 25));
+        TableView<Person> table = new GenericTableBuilder<>(data)
+                .addColumn(ColumnSpec.of("name", "Nome", p -> new SimpleStringProperty(p.name())))
+                .addColumn(ColumnSpec.number("age", "Idade", p -> new SimpleIntegerProperty(p.age())))
+                .features(TableFeatures.none().enableFiltering())
+                .build();
+
+        assertEquals(2, table.getColumns().size());
+        assertEquals("Ana", table.getColumns().get(0).getCellData(0));
+        assertEquals(25, table.getColumns().get(1).getCellData(1));
+    }
+}

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+DIR="$(cd "$(dirname "$0")"; pwd -P)"
+exec mvn -s "$DIR/settings.xml" "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+set DIR=%~dp0
+mvn -s "%DIR%settings.xml" %*

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
## Summary
- introduce ColumnSpec and TableColumnBuilder for type-safe column metadata
- add TableFeatures and TableBuilderOptions to toggle optional capabilities
- refactor GenericTableBuilder and tests to use ColumnSpec API
- add basic Maven wrapper script and settings with repo mirror

## Testing
- `./mvnw -q -f javafx-table-lib/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898adb45d6083319960a26ea01b8441